### PR TITLE
Patterns api

### DIFF
--- a/docs/source/patterns_api.rst
+++ b/docs/source/patterns_api.rst
@@ -1,19 +1,20 @@
 Patterns API
-====
+============
 
 (Abstract) Pattern Class
-....
+........................
 
 .. autoclass:: paspailleur.pattern_structures.pattern.Pattern
 
 
 Built-in Patterns
-....
+.................
 
 .. automodule:: paspailleur.pattern_structures.built_in_patterns
+   :members:
 
 
 Pattern Structure
-....
+.................
 
 .. autoclass:: paspailleur.pattern_structures.pattern_structure.PatternStructure

--- a/docs/source/patterns_api.rst
+++ b/docs/source/patterns_api.rst
@@ -1,19 +1,19 @@
 Patterns API
-============
+====
 
 (Abstract) Pattern Class
-........................
+....
 
 .. autoclass:: paspailleur.pattern_structures.pattern.Pattern
 
 
 Built-in Patterns
-.................
+....
 
 .. automodule:: paspailleur.pattern_structures.built_in_patterns
 
 
 Pattern Structure
------------------
+....
 
 .. autoclass:: paspailleur.pattern_structures.pattern_structure.PatternStructure


### PR DESCRIPTION
This is just the first modification with a headings small fix to the file.

After build the "built-in patterns" heading is remaining empty and not taking the functions of the python file which was fixed by adding `:members:` inside automodule.

And a warning is coming up for me  "WARNING: html_static_path entry '_static' does not exist" which was fixed by simply adding a _static folder inside source folder.